### PR TITLE
Added tabs functionality to requests page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,20 +59,13 @@ function App() {
           element={<AccountSetUpCompanyName />}
         />
         <Route path="/accountsetup/users" element={<Users />} />
-        <Route path="/accountsetup/email" element={<AccountSetUpEmail />} />
         <Route
           path="/isdflow/needsanalysis"
           element={<ISDFlowNeedsAnalysis />}
         />
         <Route path="/isdflow/objective" element={<Objective />} />
-        <Route
-          path="/isdflow/final"
-          element={<FinalAssessmentStrategy />}
-        />
-        <Route
-          path="/isdflow/course"
-          element={<CourseStructure />}
-        />
+        <Route path="/isdflow/final" element={<FinalAssessmentStrategy />} />
+        <Route path="/isdflow/course" element={<CourseStructure />} />
         <Route path="*" element={<Error />} />
       </Routes>
     </Router>

--- a/src/pages/Requests/Requests.jsx
+++ b/src/pages/Requests/Requests.jsx
@@ -2,8 +2,10 @@ import "./Requests.scss";
 import CircleUser from "./../../assets/icons/circle-user.svg";
 import RequestsTable from "./../../utilities/requestsLogic/table/RequestsTable";
 import NavBar from "./../../utilities/requestsLogic/navigation/NavBar";
+import { useState } from "react";
 
 const Requests = () => {
+  const [tab, setTab] = useState("active");
   return (
     <main className="requests-wrapper">
       <div className="isd-dashboard-wrapper">
@@ -14,8 +16,12 @@ const Requests = () => {
       </div>
       <div className="requests-container">
         <h1 className="title requests-title">Requests</h1>
-        <NavBar />
-        <RequestsTable />
+        <NavBar
+          onTabClicked={(tabName) => {
+            setTab(tabName);
+          }}
+        />
+        <RequestsTable tab={tab} />
       </div>
     </main>
   );

--- a/src/utilities/requestsLogic/navigation/NavBar.jsx
+++ b/src/utilities/requestsLogic/navigation/NavBar.jsx
@@ -2,18 +2,55 @@ import { Link } from "react-router-dom";
 import "./NavBar.scss";
 import FilterIcon from "./../../../assets/icons/filter.svg";
 
-const NavBar = () => {
+let activeClasses = "clicked";
+let completedClasses = "";
+let canceledClasses = "";
+
+const handleTabClick = (onTabClicked, tab) => {
+  onTabClicked(tab);
+  activeClasses = "";
+  completedClasses = "";
+  canceledClasses = "";
+  switch (tab) {
+    case "active":
+      activeClasses = "clicked";
+      break;
+    case "completed":
+      completedClasses = "clicked";
+      break;
+    case "canceled":
+      canceledClasses = "clicked";
+      break;
+  }
+};
+
+const NavBar = ({ onTabClicked }) => {
   return (
     <div className="nav-bar">
       <ul className="tabs">
         <li>
-          <button>Active</button>
+          <button
+            className={activeClasses}
+            onClick={() => handleTabClick(onTabClicked, "active")}
+          >
+            Active
+          </button>
         </li>
         <li>
-          <button>Completed</button>
+          <button
+            className={completedClasses}
+            onClick={() => handleTabClick(onTabClicked, "completed")}
+          >
+            Completed
+          </button>
         </li>
         <li>
-          <button>Canceled</button>
+          <button
+            className={canceledClasses}
+            onClick={() => handleTabClick(onTabClicked, "canceled")}
+          >
+            Canceled
+          </button>
         </li>
       </ul>
       <ul className="actions">

--- a/src/utilities/requestsLogic/navigation/NavBar.scss
+++ b/src/utilities/requestsLogic/navigation/NavBar.scss
@@ -23,10 +23,16 @@
                 padding: 0;
                 font-weight: $fontWeightRegular;
                 font-size: $font-size-small;
+                border-radius: 0px;
 
                 &:hover {
-                    border: none;
+                    font-weight: $fontWeightSemiBold;
+                    transition: font-weight 1ms;
                 }
+            }
+            .clicked {
+                font-weight: $fontWeightSemiBold;
+                border-bottom: 2px solid $font-color-black;
             }
             
         }

--- a/src/utilities/requestsLogic/table/RequestsTable.jsx
+++ b/src/utilities/requestsLogic/table/RequestsTable.jsx
@@ -33,6 +33,20 @@ let info = [
     stage: "courseStructure",
     status: "inProgress",
   },
+  {
+    requestName: "Reducing issues in manufacturing workflow",
+    assignedTo: "John Doe",
+    lastUpdated: "Fri Apr 13 2024 00:00:00 GMT-0700 (Pacific Daylight Time)",
+    stage: "needsAnalysis",
+    status: "canceled",
+  },
+  {
+    requestName: "Reducing issues in manufacturing workflow",
+    assignedTo: "John Doe",
+    lastUpdated: "Fri Apr 09 2024 00:00:00 GMT-0700 (Pacific Daylight Time)",
+    stage: "Storyboard",
+    status: "completed",
+  },
 ];
 
 //sort info by lastUpdated date:
@@ -54,8 +68,35 @@ const needReviewRequests = sortedInfo.filter((r) => {
   }
 });
 
-const RequestsTable = () => {
+// The states are: active, canceled, completed.
+// Request is in active state if its status is not completed or canceled.
+const filterRequestsByState = (requests, state) => {
+  return requests.filter((r) => {
+    if (state === "active") {
+      if (
+        r.status === "inProgress" ||
+        r.status === "updating" ||
+        r.status === "qaReview" ||
+        r.status === "supervisorReview" ||
+        r.status === "stakeholderReview"
+      ) {
+        return r;
+      }
+    }
+    if (r.status === state) {
+      return r;
+    }
+  });
+};
+
+const RequestsTable = ({ tab }) => {
   const [width, setWidth] = useState(window.innerWidth);
+  console.log("tab!!! " + tab);
+  const needReviewRequestsByState = filterRequestsByState(
+    needReviewRequests,
+    tab
+  );
+  const noReviewRequestsByState = filterRequestsByState(noReviewRequests, tab);
 
   useEffect(() => {
     const handleResize = () => {
@@ -72,16 +113,16 @@ const RequestsTable = () => {
   if (width < 1000) {
     return (
       <>
-        {needReviewRequests.length > 0 && (
+        {needReviewRequestsByState.length > 0 && (
           <section className="requests-table-small need-review">
-            {needReviewRequests.map((request, index) => (
+            {needReviewRequestsByState.map((request, index) => (
               <RequestRowSmallScreen key={index} request={request} />
             ))}
           </section>
         )}
-        {noReviewRequests.length > 0 && (
+        {noReviewRequestsByState.length > 0 && (
           <section className="requests-table-small">
-            {noReviewRequests.map((request, index) => (
+            {noReviewRequestsByState.map((request, index) => (
               <RequestRowSmallScreen key={index} request={request} />
             ))}
           </section>
@@ -101,9 +142,9 @@ const RequestsTable = () => {
           <th className="actions-header">Actions</th>
         </tr>
       </thead>
-      {needReviewRequests.length > 0 && (
+      {needReviewRequestsByState.length > 0 && (
         <tbody className="need-review">
-          {needReviewRequests.map((request, index) => (
+          {needReviewRequestsByState.map((request, index) => (
             <RequestRow key={index} request={request} />
           ))}
           <tr className="table-gap">
@@ -112,7 +153,7 @@ const RequestsTable = () => {
         </tbody>
       )}
       <tbody>
-        {noReviewRequests.map((request, index) => (
+        {noReviewRequestsByState.map((request, index) => (
           <RequestRow key={index} request={request} />
         ))}
       </tbody>

--- a/src/utilities/requestsLogic/table/statuses.js
+++ b/src/utilities/requestsLogic/table/statuses.js
@@ -1,17 +1,19 @@
 export const statuses = {
-    status: "Status",
     inProgress: "In Progress",
     updating: "Updating",
     qaReview: "QA Review",
     supervisorReview: "Supervisor Review",
     stakeholderReview: "Stakeholder Review",
+    canceled: "Canceled", //request can be cancelled during any stage
+    completed: "Completed", //temporary state, a new way to mark request completed will be provided later
   };
   
 export const statusColors = {
-    status: "grey",
     inProgress: "green",
     updating: "green",
     qaReview: "orange",
     supervisorReview: "orange",
     stakeholderReview: "orange",
+    canceled: "grey",
+    completed: "green",
   };


### PR DESCRIPTION
We have 3 states for requests: active, completed and canceled.
If the request status is not "completed" or "canceled", then it's treated as active.

<img width="888" alt="Screenshot 2024-07-23 at 12 07 16 AM" src="https://github.com/user-attachments/assets/77f39ecf-2aac-4474-9fd2-ab7ed83786a8">

<img width="910" alt="Screenshot 2024-07-23 at 12 07 26 AM" src="https://github.com/user-attachments/assets/018d6986-00cf-4cca-aae8-ab74ce46d755">

<img width="887" alt="Screenshot 2024-07-23 at 12 02 03 AM" src="https://github.com/user-attachments/assets/47cbb925-3695-4d4a-b8ac-abe942eaa1e2">
