### PR TITLE
Task 1091: make the search dropdown show members with the exact role only

### DIFF
--- a/src/pages/Review/NewCourseRequestReview/NewCourseRequestReview.jsx
+++ b/src/pages/Review/NewCourseRequestReview/NewCourseRequestReview.jsx
@@ -211,7 +211,7 @@ const NewCourseRequestReview = () => {
                         clearErrors={clearErrors}
                         submitCount={submitCount}
                         allowOnlyOneToSelect={true}
-                        // onChange={(e) => handleAssignToOnInput(e)}
+                        role={ROLES.ISD}
                       />
                       <p className="error">{errors.assignTo?.message}</p>
                     </fieldset>

--- a/src/redux/RTKQueries/membersQuery.js
+++ b/src/redux/RTKQueries/membersQuery.js
@@ -44,13 +44,19 @@ export const membersApi = createApi({
 		}),
 		updateRole: builder.mutation({
 			query: memberData => ({
-				url: 'updateRole',
+				url: '/updateRole',
 				method: 'POST',
 				body: memberData,
 			}),
+		}),
+		getMembersByOrganizationIdAndRole: builder.query({
+			query: data => ({
+				url: `/getMembersByRole?organizationId=${data.organizationId}&role=${data.role}`,
+				method: 'GET',
+			})
 		}),
 	}),
 });
 
 // Standard naming convention rtk
-export const { useAddMemberMutation, useGetMembersByOrganizationIdQuery, useLazyGetMembersByOrganizationIdQuery, useRemoveMemberMutation, useUpdateRoleMutation } = membersApi;
+export const { useAddMemberMutation, useGetMembersByOrganizationIdQuery, useLazyGetMembersByOrganizationIdQuery, useRemoveMemberMutation, useUpdateRoleMutation, useGetMembersByOrganizationIdAndRoleQuery } = membersApi;


### PR DESCRIPTION
Made the search dropdown retrieve members by a specific role. It will be used at least on Review New Course Request page (ISD Supervisor role):

<img width="1697" height="630" alt="Screenshot 2025-08-06 at 8 52 01 PM" src="https://github.com/user-attachments/assets/01b96069-3297-4cfd-873d-0899219d6dd7" />
In this search dropdown only members with ISD role should shown.

How to use the Component with a specific role - just add a role prop. If there is no role prop, all members of the organization will be retrieved:
```
<SearchPeopleField
                        name="assign_to"
                        register={register}
                        setValue={setValue}
                        setError={setError}
                        clearErrors={clearErrors}
                        submitCount={submitCount}
                        allowOnlyOneToSelect={true}
                        role={ROLES.ISD}
                      />
```
