### PR TITLE
Task 1202: Add error handling to http://localhost:5173/accountsetup/users and http://localhost:5173/members pages

### DIFF
--- a/src/pages/AccountSetUp/Users/Users.scss
+++ b/src/pages/AccountSetUp/Users/Users.scss
@@ -30,6 +30,17 @@
     width: 250px;
   
   }
+
+  .add-teammates-button {
+    cursor: pointer;
+    color: $button-blue-background;
+  }
+
+  .add-teammates-button, .remove-teammates-button {
+    background: none;
+    border: 0px;
+  }
+  
   
   @media screen and (max-width: 960px){
   

--- a/src/pages/SignUp/SignUp.scss
+++ b/src/pages/SignUp/SignUp.scss
@@ -29,12 +29,6 @@
 				transition-duration: 0.3s;
 				box-sizing: border-box;
 				padding: 12px 0px;
-
-				&:disabled {
-					background-color: #808080 !important;
-					color: #fff !important;
-					cursor: not-allowed !important;
-				}
 			}
 
 			.google-login {

--- a/src/styles/_formstyles.scss
+++ b/src/styles/_formstyles.scss
@@ -1,5 +1,26 @@
 @import './variables';
 
+button[type=submit]:disabled {
+	background-color: #808080 !important;
+	color: #fff !important;
+	cursor: not-allowed !important;
+}
+
+button[type=button]:disabled {
+	cursor: not-allowed !important;
+    color: gray !important;
+}
+
+.success-message-teammates {
+	color: green;
+	text-align: center;
+}
+
+.error-message-teammates {
+	color: red;
+	text-align: center;
+}
+
 .form-container {
 	color: $font-color-black;
 	font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;

--- a/src/utilities/modals/TeammatesModal/TeammatesModal.scss
+++ b/src/utilities/modals/TeammatesModal/TeammatesModal.scss
@@ -82,7 +82,7 @@
 			font-size: 0.8rem;
 			color: rgb(203, 21, 21);
 			font-weight: $fontWeightBold;
-			top: 48px;
+			top: 54px;
 			left: 2px;
 		}
 
@@ -99,6 +99,7 @@
 				width: 100%;
 				margin: 0;
 				min-height: 3rem;
+				margin-top: 0.5rem;
 			}
 		}
 	}
@@ -107,16 +108,21 @@
 .remove-box {
 	display: flex;
 	min-height: 3rem;
-	height: 100%;
 	margin-top: 0rem;
-
 	justify-content: center;
+	position: relative;
+    top: -0.5rem;
+
+	.remove-teammates {
+		cursor: pointer;
+		color: red;
+		background: none;
+		border: 0px;
+		align-self: flex-start;
+	}
 }
 
-.remove-teammates {
-	cursor: pointer;
-	color: red;
-}
+
 
 @media (max-width: 80rem) {
 	// overwriting react-modal settings

--- a/src/utilities/modals/TeammatesModal/submitNewMembers.js
+++ b/src/utilities/modals/TeammatesModal/submitNewMembers.js
@@ -1,0 +1,31 @@
+import { delay, retrieveAndSaveAdminRoles } from "../../utils";
+
+const submitNewMembers = async (dataToSubmit, inviteMember, setSuccessMessages, setErrorMessages, fetchUserInfo, dispatch) => {
+    // Submit each member
+    const promises = dataToSubmit.map(
+        async (member) => await inviteMember(member)
+      );
+      const results = await Promise.allSettled(promises);
+
+      // Set info and error messages
+      const successMsgs = [];
+      const errorMsgs = [];
+      results.forEach((result) => {
+        if (result.status === "fulfilled") {
+          successMsgs.push(result.value.message);
+        }
+        if (result.status === "rejected") {
+          errorMsgs.push(result.reason.data.error);
+        }
+      });
+      setSuccessMessages(successMsgs);
+      setErrorMessages(errorMsgs);
+
+      // Update roles for Admin
+      await retrieveAndSaveAdminRoles(fetchUserInfo, dispatch);
+
+      await delay(3000);
+
+}
+
+export default submitNewMembers;

--- a/src/utilities/tableCreator/teammates/apiFunctions.js
+++ b/src/utilities/tableCreator/teammates/apiFunctions.js
@@ -1,12 +1,13 @@
-export const deleteMember = async (e, cell, setMembers, data, organizationId, removeMember) => {
+export const deleteMember = async (e, cell, setMembers, data, organizationId, removeMember, updateAdminRoleInTheStore) => {
 	try {
 		e.stopPropagation();
 
 		const memberId = cell.row.original.id;
-		const memberToDelete = data.filter(member => member.id === memberId)
+		const memberToDelete = data.filter(member => member.id === memberId);
 		const memberToDeleteData = {memberId: memberToDelete[0].id, userId: memberToDelete[0].userId, organizationId: organizationId };
 
 		const result = await removeMember(memberToDeleteData);
+		updateAdminRoleInTheStore(memberToDelete[0]);
 
 		// We directly edit the array, so there is no need to refetch the members
 		setMembers(prevMembers =>

--- a/src/utilities/utils.jsx
+++ b/src/utilities/utils.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useSelector } from "react-redux";
-import { selectCurrentUserRoles } from "../redux/slices/currentUserSlice";
+import { setCurrentUserRoles } from "../redux/slices/currentUserSlice";
 
 export const MyInput = React.forwardRef(
   ({ name, id, type, label, classNameForLabel, ...rest }, ref) => {
@@ -149,4 +148,16 @@ export const transformMembersData = (members) => {
     email: member.User.email,
     userId: member.user_id,
   }));
+};
+
+// stop async functions for ms milliseconds
+export const delay = (ms) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+// to mame sure the admin roles are up-to-date, retrieve them from backend and save in the store
+export const retrieveAndSaveAdminRoles = async (fetchUserInfo, dispatch) => {
+  const userInfo = await fetchUserInfo();
+  const roles = retrieveRoleFromGetUserInfoResponse(userInfo);
+  dispatch(setCurrentUserRoles({ roles: roles }));
 };


### PR DESCRIPTION
- Added error handling to Users.jsx
- Added error hadling to TeammatesModal
- When the admin is getting or loosing the second role, admin's role is updated in the redux store accordingly

http://localhost:5173/accountsetup/users:
<img width="913" height="912" alt="Screenshot 2025-08-15 at 11 19 49 PM" src="https://github.com/user-attachments/assets/ddc51e75-3d8a-4767-9f0c-fc99f40d26f9" />

http://localhost:5173/members:
<img width="1247" height="819" alt="Screenshot 2025-08-15 at 11 21 31 PM" src="https://github.com/user-attachments/assets/fda21dc2-c9d8-4b89-9aeb-6a9d6221c617" />
