### PR TITLE
Added auth middleware that catches 401 unauthorized error and redirects the user to login page.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,4 @@
-import {
-  BrowserRouter as Router,
-  Routes,
-  Route,
-  Navigate,
-} from "react-router-dom";
+import { Routes, Route, Navigate, useNavigate } from "react-router-dom";
 import {
   Home,
   LogIn,
@@ -27,86 +22,83 @@ import {
 } from "./pages";
 import { useSelector } from "react-redux";
 import { selectCurrentToken } from "./redux/slices/authSlice";
+import { history } from "./utilities/_helpers";
 
 const ProtectedRoute = ({ token, children }) => {
   return token ? children : <Navigate to="/" replace={true} />;
 };
 
 function App() {
+  history.navigate = useNavigate();
   const token = useSelector(selectCurrentToken);
 
   return (
-    <Router>
-      <Routes>
-        {token ? (
-          <Route path="/" element={<Requests />} />
-        ) : (
-          <Route path="/" element={<Home />} />
-        )}
-        <Route path="/login" element={<LogIn />} />
-        <Route path="/signup" element={<SignUp />} />
+    <Routes>
+      {token ? (
+        <Route path="/" element={<Requests />} />
+      ) : (
+        <Route path="/" element={<Home />} />
+      )}
+      <Route path="/login" element={<LogIn />} />
+      <Route path="/signup" element={<SignUp />} />
 
-        <Route
-          path="/*"
-          element={
-            <ProtectedRoute token={token}>
-              <Routes>
-                <Route path="/requests" element={<Requests />} />
-                <Route path="/course_request" element={<CourseRequest />} />
-                <Route
-                  path="/course_request/:currentRequestId"
-                  element={<CourseRequestById />}
-                />
-                <Route
-                  path="/accountsetup/email"
-                  element={<AccountSetUpEmail />}
-                />
-                <Route path="/members" element={<TeamMembers />} />
-                <Route
-                  path="/accountsetup/name_password"
-                  element={<AccountSetUpNamePassword />}
-                />
-                <Route
-                  path="/accountsetup/company_name"
-                  element={<AccountSetUpCompanyName />}
-                />
-                <Route
-                  path="/accountsetup/account_successfully_created"
-                  element={<AccountSetUpAccountSuccessfullyCreated />}
-                />
-                <Route path="/accountsetup/users" element={<Users />} />
-                <Route
-                  path="/isdflow/needs_analysis"
-                  element={<ISDFlowNeedsAnalysis />}
-                />
-                <Route
-                  path="/isdflow/objective"
-                  element={<ISDFlowObjective />}
-                />
-                <Route
-                  path="/isdflow/final_assessment_strategy"
-                  element={<ISDFlowFinalAssessmentStrategy />}
-                />
-                <Route
-                  path="/isdflow/course_structure"
-                  element={<ISDFlowCourseStructure />}
-                />
-                <Route
-                  path="/isdflow/course_strategy_document"
-                  element={<ISDFlowCourseStrategyDocument />}
-                />
-                <Route
-                  path="/review/new_course_request/:currentRequestId"
-                  element={<NewCourseRequestReview />}
-                />
-              </Routes>
-            </ProtectedRoute>
-          }
-        />
+      <Route
+        path="/*"
+        element={
+          <ProtectedRoute token={token}>
+            <Routes>
+              <Route path="/requests" element={<Requests />} />
+              <Route path="/course_request" element={<CourseRequest />} />
+              <Route
+                path="/course_request/:currentRequestId"
+                element={<CourseRequestById />}
+              />
+              <Route
+                path="/accountsetup/email"
+                element={<AccountSetUpEmail />}
+              />
+              <Route path="/members" element={<TeamMembers />} />
+              <Route
+                path="/accountsetup/name_password"
+                element={<AccountSetUpNamePassword />}
+              />
+              <Route
+                path="/accountsetup/company_name"
+                element={<AccountSetUpCompanyName />}
+              />
+              <Route
+                path="/accountsetup/account_successfully_created"
+                element={<AccountSetUpAccountSuccessfullyCreated />}
+              />
+              <Route path="/accountsetup/users" element={<Users />} />
+              <Route
+                path="/isdflow/needs_analysis"
+                element={<ISDFlowNeedsAnalysis />}
+              />
+              <Route path="/isdflow/objective" element={<ISDFlowObjective />} />
+              <Route
+                path="/isdflow/final_assessment_strategy"
+                element={<ISDFlowFinalAssessmentStrategy />}
+              />
+              <Route
+                path="/isdflow/course_structure"
+                element={<ISDFlowCourseStructure />}
+              />
+              <Route
+                path="/isdflow/course_strategy_document"
+                element={<ISDFlowCourseStrategyDocument />}
+              />
+              <Route
+                path="/review/new_course_request/:currentRequestId"
+                element={<NewCourseRequestReview />}
+              />
+            </Routes>
+          </ProtectedRoute>
+        }
+      />
 
-        <Route path="*" element={<Error />} />
-      </Routes>
-    </Router>
+      <Route path="*" element={<Error />} />
+    </Routes>
   );
 }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,14 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
-import { Provider } from 'react-redux';
-import './index.scss';
-import store from './store.js';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+import { Provider } from "react-redux";
+import "./index.scss";
+import store from "./store.js";
+import { BrowserRouter as Router } from "react-router-dom";
 
-ReactDOM.createRoot(document.getElementById('root')).render(
-	<Provider store={store}>
-		<React.StrictMode>
-			<App />
-		</React.StrictMode>
-	</Provider>,
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <Provider store={store}>
+    <React.StrictMode>
+      <Router>
+        <App />
+      </Router>
+    </React.StrictMode>
+  </Provider>
 );

--- a/src/redux/middleware/authInterceptor.js
+++ b/src/redux/middleware/authInterceptor.js
@@ -1,0 +1,12 @@
+import { history } from "../../utilities/_helpers";
+import { userLoggedOut } from "../slices/authSlice";
+
+const authInterceptor = ({dispatch}) => (next) => (action) => {
+    if (action?.payload?.status === 401) {
+        dispatch(userLoggedOut());
+        history.navigate("login")
+    }
+    return next(action)
+;};
+
+export default authInterceptor;

--- a/src/store.js
+++ b/src/store.js
@@ -11,6 +11,7 @@ import { requestsApi } from './redux/RTKQueries/requestsQuery';
 import { usersApi } from './redux/RTKQueries/usersQuery';
 import { companyApi } from './redux/RTKQueries/companyQuery';
 import { membersApi } from './redux/RTKQueries/membersQuery';
+import authInterceptor from './redux/middleware/authInterceptor';
 
 const store = configureStore({
 	reducer: {
@@ -32,6 +33,7 @@ const store = configureStore({
 			usersApi.middleware,
 			companyApi.middleware,
 			membersApi.middleware,
+			authInterceptor,
 		),
 });
 

--- a/src/utilities/_helpers.js
+++ b/src/utilities/_helpers.js
@@ -1,0 +1,3 @@
+export const history = {
+    navigate: null
+}


### PR DESCRIPTION
How to test:
Before the fix: 
If the user was logged in and let's say was working on http://localhost:5173/requests page. Then the user just stopped working and left the page http://localhost:5173/requests opened for 24 hours. When the user is back in 24 hours, and tries to continue working with requests, the user will see the page http://localhost:5173/requests, but no requests will be loaded, because the authorization token has expired.
After the fix:
When the user comes back to the opened page in 24 hours, he will be redirected to login page automatically if the authorization token has expired.
